### PR TITLE
Secretary Request Approval/Rejection + Email System

### DIFF
--- a/backend/controllers/secretaryController.js
+++ b/backend/controllers/secretaryController.js
@@ -2,6 +2,8 @@ import db from "../config/db.js";
 import { sendSuccess, sendError } from "../utils/responses.js";
 import { formatDate, safeParseJSON } from "../utils/formats.js";
 import { getPriority } from "../utils/labels.js";
+import { sendRequestStatusEmail } from "../utils/notificationService.js";
+import { text } from "express";
 
 const requireSecretary = (req, res) => {
     if (!req.user) {
@@ -185,9 +187,17 @@ export const approveRequest = async (req, res) => {
                 r.Req_ID,
                 r.RType_ID,
                 r.Priority,
-                rt.RType_Name
+                rt.RType_Name,
+                c.Email,
+                CONCAT(
+                    'REQ-',
+                    DATE_FORMAT(r.DateMade, '%y'),
+                    LPAD(rt.RType_ID, 2, '0'),
+                    LPAD(r.Req_ID, 3, '0')
+                ) AS RequestNumber
             FROM REQUEST r
             JOIN REQUEST_TYPES rt ON r.RType_ID = rt.RType_ID
+            JOIN CITIZEN c ON r.C_ID = c.C_ID
             WHERE r.Req_ID = ?
             `,
             [id]
@@ -201,7 +211,7 @@ export const approveRequest = async (req, res) => {
         const request = reqRows[0];
 
         const roleName = getRoleNameFromRequestType(request.RType_ID);
-        
+
         const [roleRows] = await connection.query(
             `SELECT Role_ID FROM ROLES WHERE Role_Type = ?`,
             [roleName]
@@ -259,6 +269,19 @@ export const approveRequest = async (req, res) => {
 
         await connection.commit();
 
+        try {
+            await sendRequestStatusEmail({
+                email: request.Email,
+                status: "approved",
+                requestNumber: request.RequestNumber,
+                reqId: request.Req_ID,
+                title: request.RType_Name,
+                reason: null
+            });
+        } catch (e) {
+            console.error("Email failed", e);
+        }
+
         return sendSuccess(res, "Request approved and task created");
 
     } catch (err) {
@@ -274,17 +297,49 @@ export const rejectRequest = async (req, res) => {
     if (!requireSecretary(req, res)) return;
 
     const { id } = req.params;
+    const {rejTitle, rejText } = req.body;
 
     if (!id || isNaN(id)) {
         return sendError(res, 400, "Invalid request ID", "BAD_REQUEST_ID");
     }
 
+    if (!rejTitle?.trim() || !rejText?.trim()) {
+        return sendError(res, 400, "Rejection title and message required", "MISSING_REJECTION_DATA");
+    }
+
     try {
+        const [rows] = await db.promise().query(
+            `
+            SELECT 
+                r.Req_ID,
+                r.RType_ID,
+                rt.RType_Name,
+                c.Email,
+                CONCAT(
+                    'REQ-',
+                    DATE_FORMAT(r.DateMade, '%y'),
+                    LPAD(rt.RType_ID, 2, '0'),
+                    LPAD(r.Req_ID, 3, '0')
+                ) AS RequestNumber
+            FROM REQUEST r
+            JOIN REQUEST_TYPES rt ON r.RType_ID = rt.RType_ID
+            JOIN CITIZEN c ON r.C_ID = c.C_ID
+            WHERE r.Req_ID = ?
+            `,
+            [id]
+        );
+
+        if (!rows.length) {
+            return sendError(res, 404, "Request not found", "REQ_NOT_FOUND");
+        }
+
+        const request = rows[0];
+
         const [result] = await db.promise().query(
             `
             UPDATE REQUEST 
             SET FlagRejected = 1,
-                RStat_Code = 3 -- adjust this to your "Rejected" status code
+                RStat_Code = 3
             WHERE Req_ID = ?
             `,
             [id]
@@ -292,6 +347,19 @@ export const rejectRequest = async (req, res) => {
 
         if (result.affectedRows === 0) {
             return sendError(res, 404, "Request not found", "REQ_NOT_FOUND");
+        }
+
+        try {
+            await sendRequestStatusEmail({
+                email: request.Email,
+                status: "rejected",
+                requestNumber: request.RequestNumber,
+                reqId: request.Req_ID,
+                title: request.RType_Name,
+                reason: `${rejTitle}: ${rejText}`
+            });
+        } catch (e) {
+            console.error("EMAIL FAILED", e);
         }
 
         return sendSuccess(res, "Request rejected successfully");

--- a/backend/controllers/secretaryController.js
+++ b/backend/controllers/secretaryController.js
@@ -269,3 +269,35 @@ export const approveRequest = async (req, res) => {
         connection.release();
     }
 };
+
+export const rejectRequest = async (req, res) => {
+    if (!requireSecretary(req, res)) return;
+
+    const { id } = req.params;
+
+    if (!id || isNaN(id)) {
+        return sendError(res, 400, "Invalid request ID", "BAD_REQUEST_ID");
+    }
+
+    try {
+        const [result] = await db.promise().query(
+            `
+            UPDATE REQUEST 
+            SET FlagRejected = 1,
+                RStat_Code = 3 -- adjust this to your "Rejected" status code
+            WHERE Req_ID = ?
+            `,
+            [id]
+        );
+
+        if (result.affectedRows === 0) {
+            return sendError(res, 404, "Request not found", "REQ_NOT_FOUND");
+        }
+
+        return sendSuccess(res, "Request rejected successfully");
+
+    } catch (err) {
+        console.error("REJECT ERROR:", err);
+        return sendError(res, 500, "Failed to reject request", "REJECT_ERROR");
+    }
+};

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -14,7 +14,8 @@
         "dotenv": "^17.4.0",
         "express": "^5.2.1",
         "jsonwebtoken": "^9.0.3",
-        "mysql2": "^3.20.0"
+        "mysql2": "^3.20.0",
+        "nodemailer": "^8.0.7"
       }
     },
     "node_modules/@types/node": {
@@ -782,6 +783,15 @@
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
         "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.7.tgz",
+      "integrity": "sha512-pkjE4mkBzQjdJT4/UmlKl3pX0rC9fZmjh7c6C9o7lv66Ac6w9WCnzPzhbPNxwZAzlF4mdq4CSWB5+FbK6FWCow==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/object-assign": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -16,6 +16,7 @@
     "dotenv": "^17.4.0",
     "express": "^5.2.1",
     "jsonwebtoken": "^9.0.3",
-    "mysql2": "^3.20.0"
+    "mysql2": "^3.20.0",
+    "nodemailer": "^8.0.7"
   }
 }

--- a/backend/routes/secretaryRoutes.js
+++ b/backend/routes/secretaryRoutes.js
@@ -1,7 +1,7 @@
 import express from "express";
 import { authMiddleware } from "../middleware/authMiddleware.js";
 
-import { getSubmittedRequests, getRequestDetails, getRequestDocuments,approveRequest} from "../controllers/secretaryController.js";
+import { getSubmittedRequests, getRequestDetails, getRequestDocuments, approveRequest, rejectRequest} from "../controllers/secretaryController.js";
 
 const router = express.Router();
 
@@ -11,5 +11,6 @@ router.get("/requests", getSubmittedRequests);
 router.get("/requests/:id", getRequestDetails);
 router.get("/requests/:id/documents", getRequestDocuments);
 router.post("/requests/:id/approve", approveRequest);
+router.post("/requests/:id/reject", rejectRequest);
 
 export default router;

--- a/backend/utils/labels.js
+++ b/backend/utils/labels.js
@@ -4,38 +4,6 @@ export const getPriority = (priorityCode) => {
     return "Low";
 };
 
-<<<<<<< HEAD
-const REQUEST_ROLE_MAP = {
-    // Mayor
-    1: 2,
-    2: 2,
-    3: 2,
-    // Secretary
-    4: 3,
-    5: 3,
-    6: 3,
-    7: 3,
-    // Lawyer
-    8: 4,
-    9: 4,
-    10: 4,
-    11: 4,
-    // Engineer
-    12: 5,
-    13: 5,
-    14: 5,
-    15: 5,
-    16: 5,
-    // Finance
-    17: 6,
-    18: 6,
-    // Staff
-    19: 7
-};
-
-export const getRoleForRequestType = (requestTypeId) => {
-    return REQUEST_ROLE_MAP[requestTypeId] || 7;
-=======
 const ROLE_REQUEST_MAP = {
     Mayor: [1, 2, 3],
     Secretary: [4, 5, 6, 7],
@@ -62,5 +30,4 @@ export const getRoleForRequestType = (requestTypeId) => {
     }
 
     return ROLE_TO_ID.Staff;
->>>>>>> 7302d69 (fixed secretary task assignment)
 };

--- a/backend/utils/notificationService.js
+++ b/backend/utils/notificationService.js
@@ -1,0 +1,9 @@
+import nodemailer from "nodemailer0";
+
+const transporter = nodemailer.createTransport({
+    service: "gmail",
+    auth: {
+        user: process.env.EMAIL_USER,
+        pass: process.env.EMAIL_PASS
+    }
+})

--- a/backend/utils/notificationService.js
+++ b/backend/utils/notificationService.js
@@ -1,4 +1,5 @@
-import nodemailer from "nodemailer0";
+import nodemailer from "nodemailer";
+import db from "../config/db.js";
 
 const transporter = nodemailer.createTransport({
     service: "gmail",
@@ -6,4 +7,54 @@ const transporter = nodemailer.createTransport({
         user: process.env.EMAIL_USER,
         pass: process.env.EMAIL_PASS
     }
-})
+});
+
+export const sendRequestStatusEmail = async ({
+    email,
+    status,
+    requestNumber,
+    reqId,
+    title,
+    reason
+}) => {
+    let subject = "";
+    let text = "";
+
+    if (status === "approved") {
+        subject = "Request Approved";
+        text = `Your request (${requestNumber} - ${title}) has been approved.`;
+    }
+
+    if (status === "rejected") {
+        subject = "Request Rejected";
+        text = `Your request (${requestNumber} - ${title}) was rejected.\n\nReason:\n${reason || "Not provided"}`;
+    }
+
+    await transporter.sendMail({
+        from: `"Municipality System" <${process.env.EMAIL_USER}>`,
+        to: email,
+        subject,
+        text
+    });
+
+    await saveNotification({
+        title: subject,
+        text,
+        reqId
+    });
+};
+
+export const saveNotification = async ({
+    title,
+    text,
+    reqId = null,
+    feeId = null
+}) => {
+    await db.promise().query(
+        `
+        INSERT INTO NOTIFICATION (Title, Text, DateSent, Req_ID, Fee_ID)
+        VALUES (?, ?, NOW(), ?, ?)
+        `,
+        [title, text, reqId, feeId]
+    );
+};

--- a/front-end/src/Components/Form/RejectionReason.js
+++ b/front-end/src/Components/Form/RejectionReason.js
@@ -1,0 +1,82 @@
+import { useState } from "react";
+import styles from "./RejectionReason.module.css";
+
+function RejectionReason({ onSubmit, onCancel, loading = false }) {
+    const [title, setTitle] = useState("");
+    const [text, setText] = useState("");
+    const [error, setError] = useState("");
+
+
+    const handleSubmit = (e) => {
+        e.preventDefault();
+
+        if (!title.trim() || !text.trim()){
+            setError("All fields are required");
+            return;
+        };
+
+        setError("");
+
+        onSubmit({
+            title,
+            text
+        });
+    };
+
+    return (
+        <div className={styles.overlay}>
+            <div className={styles.modal}>
+
+                <h2 className={styles.heading}>Add Rejection Reason</h2>
+
+                <form onSubmit={handleSubmit} className={styles.form}>
+
+                    <div className={styles.field}>
+                        <label>Title</label>
+                        <input
+                            type="text"
+                            value={title}
+                            onChange={(e) => setTitle(e.target.value)}
+                            placeholder="Enter title..."
+                        />
+                    </div>
+
+                    <div className={styles.field}>
+                        <label>Message</label>
+                        <textarea
+                            value={text}
+                            onChange={(e) => setText(e.target.value)}
+                            placeholder="Explain why the request is rejected..."
+                            rows={4}
+                        />
+                    </div>
+
+                    {error && (
+                        <p className={styles.errorText}>{error}</p>
+                    )}
+
+                    <div className={styles.actions}>
+                        <button
+                            type="button"
+                            onClick={onCancel}
+                            className={styles.cancelBtn}
+                        >
+                            Cancel
+                        </button>
+
+                        <button
+                            type="submit"
+                            disabled={loading}
+                            className={styles.submitBtn}
+                        >
+                            {loading ? "Sending..." : "Send"}
+                        </button>
+                    </div>
+
+                </form>
+            </div>
+        </div>
+    );
+}
+
+export default RejectionReason;

--- a/front-end/src/Components/Form/RejectionReason.module.css
+++ b/front-end/src/Components/Form/RejectionReason.module.css
@@ -1,0 +1,141 @@
+.overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+
+    background: rgba(0, 0, 0, 0.5);
+
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    z-index: 1000;
+}
+
+.modal {
+    background: var(--white-background);
+    padding: 20px;
+    border-radius: 12px;
+
+    width: 100%;
+    max-width: 420px;
+
+    box-shadow: var(--shadow);
+
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+}
+
+.heading {
+    font-size: 18px;
+    font-weight: 600;
+    color: var(--text-dark);
+}
+
+.form {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.field {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.field label {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--text-dark-muted);
+}
+
+.field input,
+.field textarea {
+    padding: 8px 10px;
+    border-radius: 8px;
+    border: 1px solid var(--border-color);
+
+    font-size: 14px;
+    font-family: inherit;
+
+    background: #fff;
+    color: var(--text-main);
+
+    transition: 0.2s ease;
+}
+
+.field input:focus,
+.field textarea:focus {
+    outline: none;
+    border-color: var(--primary);
+    box-shadow: 0 0 0 2px rgba(28, 99, 191, 0.15);
+}
+
+.field textarea {
+    resize: none;
+}
+
+.actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 10px;
+    margin-top: 6px;
+}
+
+.cancelBtn {
+    background: transparent;
+    border: none;
+    cursor: pointer;
+
+    font-weight: 500;
+    color: var(--text-dark-muted);
+
+    padding: 6px 10px;
+    border-radius: 6px;
+
+    transition: 0.2s ease;
+}
+
+.cancelBtn:hover {
+    background: rgba(0, 0, 0, 0.05);
+    color: var(--text-dark);
+}
+
+.submitBtn {
+    background: #ef4444;
+    color: var(--text-light);
+    border: none;
+
+    padding: 8px 14px;
+    border-radius: 8px;
+
+    font-weight: 600;
+    cursor: pointer;
+
+    transition: 0.2s ease;
+}
+
+.submitBtn:hover {
+    background: #dc2626;
+    transform: translateY(-1px);
+}
+
+.submitBtn:active {
+    transform: translateY(0);
+}
+
+.submitBtn:disabled {
+    background: #94a3b8;
+    cursor: not-allowed;
+    transform: none;
+}
+
+.errorText {
+    font-size: 12px;
+    color: #ef4444;
+    margin-top: -4px;
+}

--- a/front-end/src/Pages/Secretary/RequestDetailsPage.js
+++ b/front-end/src/Pages/Secretary/RequestDetailsPage.js
@@ -93,16 +93,15 @@ function RequestDetails() {
         }
     };
 
-    const handleReject = async () => {
+    const handleReject = async (title, text) => {
         try {
             setRejecting(true);
 
             const res = await axios.post(
                 `${API_URL}/secretary/requests/${id}/reject`,
-                {},
-                {
-                    headers: { Authorization: `Bearer ${token}` }
-                }
+                {rejTitle: title, rejText: text},
+                
+                {headers: { Authorization: `Bearer ${token}` }}
             );
 
             if (res.data.success) {
@@ -170,7 +169,7 @@ function RequestDetails() {
                     onSubmit={async ({ title, text }) => {
                         const success = await handleReject(title, text);
                         if (success) {
-                            setShowRejectModal(false); // ✅ only close on success
+                            setShowRejectModal(false);
                         }
                     }}
                 />

--- a/front-end/src/Pages/Secretary/RequestDetailsPage.js
+++ b/front-end/src/Pages/Secretary/RequestDetailsPage.js
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import axios from "axios";
 import { useNavigate, useParams } from "react-router-dom";
 import { FaArrowLeft } from "react-icons/fa";
-
+import RejectionReason from "../../Components/Form/RejectionReason";
 import RequestDetailsCard from "../../Components/Card/RequestDetailsCard";
 import styles from "./RequestDetailsPage.module.css";
 
@@ -18,6 +18,9 @@ function RequestDetails() {
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState("");
     const [approving, setApproving] = useState(false);
+    const [rejecting, setRejecting] = useState(false);
+    const [showRejectModal, setShowRejectModal] = useState(false);
+
 
     useEffect(() => {
         const fetchData = async () => {
@@ -90,6 +93,40 @@ function RequestDetails() {
         }
     };
 
+    const handleReject = async () => {
+        try {
+            setRejecting(true);
+
+            const res = await axios.post(
+                `${API_URL}/secretary/requests/${id}/reject`,
+                {},
+                {
+                    headers: { Authorization: `Bearer ${token}` }
+                }
+            );
+
+            if (res.data.success) {
+                setRequest(prev => ({
+                    ...prev,
+                    status: "Rejected"
+                }));
+                return true;
+            } else {
+                setError(res.data.message);
+                return false;
+            }
+
+        } catch (err) {
+            console.error(err);
+            setError(
+                err.response?.data?.message ||
+                "Failed to reject request"
+            );
+        } finally {
+            setRejecting(false);
+        }
+    };
+
     if (error) {
         return <h1 className={styles.error}>{error}</h1>;
     }
@@ -108,14 +145,36 @@ function RequestDetails() {
             <RequestDetailsCard request={request} />
 
             {request.status === "Submitted" || request.status === "Under Review" ? (
-                <button
-                    className={styles.approveBtn}
-                    onClick={handleApprove}
-                    disabled={approving}
-                >
-                    {approving ? "Approving..." : "Approve Request"}
-                </button>
+                <div className={styles.btnContainer}>
+                    <button
+                        className={styles.approveBtn}
+                        onClick={handleApprove}
+                        disabled={approving}
+                    >
+                        {approving ? "Approving..." : "Approve Request"}
+                    </button>
+
+                    <button
+                        className={styles.rejectBtn}
+                        onClick={() => setShowRejectModal(true)}
+                    >
+                        {rejecting ? "Rejecting..." : "Reject Request"}
+                    </button>
+                </div>
             ) : null}
+
+            {showRejectModal && (
+                <RejectionReason
+                    loading={rejecting}
+                    onCancel={() => setShowRejectModal(false)}
+                    onSubmit={async ({ title, text }) => {
+                        const success = await handleReject(title, text);
+                        if (success) {
+                            setShowRejectModal(false); // ✅ only close on success
+                        }
+                    }}
+                />
+            )}
 
             <div className={styles.docsBox}>
                 <h2 className={styles.sectionTitle}>Citizen Documents</h2>

--- a/front-end/src/Pages/Secretary/RequestDetailsPage.module.css
+++ b/front-end/src/Pages/Secretary/RequestDetailsPage.module.css
@@ -5,6 +5,7 @@
     gap: 16px;
 }
 
+/* Back button */
 .backBtn {
     display: inline-flex;
     align-items: center;
@@ -21,6 +22,7 @@
     padding: 4px 0;
 }
 
+/* Sections */
 .sectionTitle {
     font-size: 16px;
     font-weight: 600;
@@ -35,6 +37,7 @@
     gap: 10px;
 }
 
+/* Document card */
 .docCard {
     display: flex;
     justify-content: space-between;
@@ -83,6 +86,7 @@
     color: #ef4444;
 }
 
+/* View button */
 .viewBtn {
     padding: 6px 10px;
     border-radius: 8px;
@@ -100,6 +104,14 @@
     background: var(--primary-dark);
 }
 
+/* Buttons container */
+.btnContainer {
+    display: flex;
+    flex-direction: row;
+    gap: 15px;
+}
+
+/* Approve button */
 .approveBtn {
     margin-top: 10px;
     align-self: flex-start;
@@ -128,6 +140,40 @@
 }
 
 .approveBtn:disabled {
+    background: #94a3b8;
+    cursor: not-allowed;
+    transform: none;
+}
+
+/* Reject button (fixed to match approve) */
+.rejectBtn {
+    margin-top: 10px;
+    align-self: flex-start;
+
+    padding: 10px 16px;
+    border-radius: 10px;
+    border: none;
+
+    background: #ef4444;
+    color: white;
+
+    font-size: 14px;
+    font-weight: 600;
+
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.rejectBtn:hover {
+    background: #dc2626;
+    transform: translateY(-1px);
+}
+
+.rejectBtn:active {
+    transform: translateY(0);
+}
+
+.rejectBtn:disabled {
     background: #94a3b8;
     cursor: not-allowed;
     transform: none;

--- a/front-end/src/index.css
+++ b/front-end/src/index.css
@@ -17,7 +17,7 @@
   /* in request page */
   --bg-light: #f8fafc;
   --text-main: #1e293b;
-  --text-muted: #64748b;
+  --text-muted: #cacaca;
   --border-color: #e2e8f0;
   /**/
 

--- a/front-end/src/index.css
+++ b/front-end/src/index.css
@@ -26,7 +26,6 @@
   --Light-Beige: #fdf6f1;
 
   --text-light: #ffffff;
-  --text-muted: #cacaca;
   --text-dark: #222;
   --text-dark-muted: #434343;
 


### PR DESCRIPTION
## Overview
Fixed secretary approval logic and added rejection button requiring justification before submitting. Also added notification by email system using `Nodemailer` (Sender email to be given out privately).
Improvements to front end look.

## Changes
### 1. Email and Notif Service
- Added reusable `sendRequestStatusEmail` utility that uses nodemailer to send automatic emails on status changes (only approve and reject implemented now)
- Emails include: Request Number, Request Title, Rejection Reason if applicable

### 2. Database Logging
- Added automatic notification logging to the database where notifications are inserted on send (title, text, datesend and req_id)
- No in app notification system to save time

### 3. Fixed Flows

**Approval Flow:**
- Fetches citizen email + request metadata
- Assigns employee task based on role + workload balancing
- Updates request status to “Assigned”
- Sends approval email to citizen
- Saves notification record

**Rejection Flow:**

- Added validation for rejection payload (rejTitle, rejText)
- Fetches request + citizen email + formatted request number
- Updates request status to “Rejected”
- Sends email including: Request number, Request title, Rejection reason (title + message combined)
- Saves notification record
- Added proper error handling for missing rejection data

### 4. Frontend Reusable Rejection Form
- Added a new rejection form that requires a title and some text explaining ther reason of rejection
- Prevents submission until all fields are filled

**NOTES:** these changes are implemented for Secretary but they can be used later on to send notifications at any point in the request processing cycle. Due to time constraints, this will not be implemented now.